### PR TITLE
✨ NEW: validate entered github username

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ $ pip install -U cookiecutter
 ```bash
 $ cookiecutter git@github.com:executablebooks/cookiecutter-jupyter-book.git
 
-author_name [Captain Planet]: Tomas Beuzen
+author_name [Captain Jupyter]: Tomas Beuzen
 github_username [tomasbeuzen]:
 book_name [my-book]:
 book_slug [my_book]:

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-  "author_name": "Captain Planet",
+  "author_name": "Captain Jupyter",
   "github_username": "{{ cookiecutter.author_name.lower().replace(' ', '') }}",
   "book_name": "my-book",
   "book_slug": "{{ cookiecutter.book_name.lower().replace(' ', '_').replace('-', '_') }}",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,6 +1,11 @@
 # This script cleans up github workflows post CC generation
 import os
 import shutil
+import requests
+from textwrap import dedent
+
+##############################################################################
+# Path utilities
 
 
 def remove(filepath):
@@ -10,9 +15,62 @@ def remove(filepath):
         shutil.rmtree(filepath)
 
 
+##############################################################################
+# CLI utilities
+
+border = "=" * 79
+endc = "\033[0m"
+bcolors = dict(
+    blue="\033[94m",
+    green="\033[92m",
+    orange="\033[93m",
+    red="\033[91m",
+    bold="\033[1m",
+    underline="\033[4m",
+)
+
+
+def _color_message(msg, style):
+    return bcolors[style] + msg + endc
+
+
+def _message_box(msg, color="green", doprint=True, print_func=print):
+    # Prepare the message so the indentation is the same as the box
+    msg = dedent(msg)
+
+    # Color and create the box
+    border_colored = _color_message(border, color)
+    box = """
+    {border_colored}
+    {msg}
+    {border_colored}
+    """
+    box = dedent(box).format(msg=msg, border_colored=border_colored)
+    if doprint is True:
+        print_func(box)
+    return box
+
+
+##############################################################################
+# Post-gen script
+
 no_workflow = "{{cookiecutter.include_github_actions}}" == "no"
 
 if no_workflow:
     # remove top-level file inside the generated folder
     remove(".github/")
 
+
+if (
+    not requests.get(
+        "http://www.github.com/{{cookiecutter.github_username}}"
+    ).status_code
+    < 400
+):
+    _message_box(
+        "WARNING:\n"
+        "Could not find the user '{{cookiecutter.github_username}}' on github.com.\n"
+        "Please check the 'github_username' you entered.\n"
+        "If you are not using github.com you may ignore this warning.",
+        color="orange",
+    )


### PR DESCRIPTION
The cookiecutter now validates if the entered username is a valid username on GitHub and if not, throws a colourful warning (not an error), as shown below:

```sh
author_name [Captain Jupyter]: 
github_username [captainjupyter]: 
book_name [my-book]: 
book_slug [my_book]: 
book_short_description [This cookiecutter creates a simple boilerplate for a Jupyter Book.]: 
version ['0.1.0']: 
Select open_source_license:
1 - MIT license
2 - BSD license
3 - ISC license
4 - Apache Software License 2.0
5 - GNU General Public License v3
Choose from 1, 2, 3, 4, 5 [1]: 
Select include_github_actions:
1 - yes
2 - no
Choose from 1, 2 [1]: 

===============================================================================
WARNING:
Could not find the user 'captainjupyter' on github.com.
Please check the 'github_username' you entered.
If you are not using github.com you may ignore this warning.
===============================================================================
```

Closes #3 