### PR TITLE
🐛 FIX: bad reference in LICENSE

### DIFF
--- a/{{cookiecutter.book_slug}}/LICENSE
+++ b/{{cookiecutter.book_slug}}/LICENSE
@@ -79,7 +79,7 @@ limitations under the License.
 GNU GENERAL PUBLIC LICENSE
                       Version 3, 29 June 2007
 
-    {{ cookiecutter.project_short_description }}
+    {{ cookiecutter.book_short_description }}
     Copyright (C) {% now 'local', '%Y' %}  {{ cookiecutter.author_name }}
 
     This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
Modified a bad cookiecutter reference in LICENSE

Fixes #15 