### PR TITLE
🔧 MAINTAIN: change "master" to "main" in all docs and templates

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,8 @@ jobs:
         jupyter-book build my_book/my_book/
     # Deploy html to gh-pages
     - name: GitHub Pages action
-      uses: peaceiris/actions-gh-pages@v3.6.4
+      uses: peaceiris/actions-gh-pages@v3.6.1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: my_book/my_book/_build/html
+        publish_branch: gh-pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,10 @@
 name: deploy
 
 on:
-  # Trigger the deploy on push to master branch
+  # Trigger the deploy on push to main branch
   push:
     branches:
-      - master
+      - main
   schedule:
     # jupyter-book is updated regularly, let's run this deployment every month in case something fails
     # <minute [0,59]> <hour [0,23]> <day of the month [1,31]> <month of the year [1,12]> <day of the week [0,6]>
@@ -45,7 +45,7 @@ jobs:
         jupyter-book build my_book/my_book/
     # Deploy html to gh-pages
     - name: GitHub Pages action
-      uses: peaceiris/actions-gh-pages@v3.6.1
+      uses: peaceiris/actions-gh-pages@v3.6.4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: my_book/my_book/_build/html

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
         jupyter-book build my_book/my_book/
     # Push example book to gh-pages-test
     - name: GitHub Pages action
-      uses: peaceiris/actions-gh-pages@v3.6.4
+      uses: peaceiris/actions-gh-pages@v3.6.1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: my_book/my_book/_build/html

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,13 +1,13 @@
 name: tests
 
 on:
-  # Trigger the workflow on push or pull request on master branch
+  # Trigger the workflow on push or pull request on main branch
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
   schedule:
     # Run cron job every month, https://crontab.guru/every-month
     - cron: '0 0 1 * *'
@@ -46,7 +46,7 @@ jobs:
         jupyter-book build my_book/my_book/
     # Push example book to gh-pages-test
     - name: GitHub Pages action
-      uses: peaceiris/actions-gh-pages@v3.6.1
+      uses: peaceiris/actions-gh-pages@v3.6.4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: my_book/my_book/_build/html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,4 +57,4 @@ git commit -m "Your detailed description of your changes."
 git push origin name-of-your-bugfix-or-feature
 ```
 
-5. Open a pull request through the GitHub website. Naming convention for pull requests is [detailed here](https://github.com/executablebooks/.github/blob/master/CONTRIBUTING.md#commit-messages). For example, a pull request that adds a new feature might be titled: `✨ NEW: validate entered github username`.
+5. Open a pull request through the GitHub website. Naming convention for pull requests is [detailed here](https://github.com/executablebooks/.github/blob/main/CONTRIBUTING.md#commit-messages). For example, a pull request that adds a new feature might be titled: `✨ NEW: validate entered github username`.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ $ jupyter-book build my_book/
       $ git add .
       $ git commit -m "first commit"
       $ git remote add origin git@github.com:<user>/<repository-name>.git
-      $ git push -u origin master
+      $ git push -u origin main
       ```
 
    4. The GitHub Actions workflow provided with the cookiecutter (`my_book/.github/workflows/deploy.yml`) will automatically deploy your book to the `gh-pages` branch of your repository once pushed. It is typically available after a few minutes at `https://<user>.github.io/<myonlinebook>/`. You may need to go to the `Settings` tab of your repository and under the **GitHub Pages** heading, choose the `gh-pages branch` from the **Source** drop-down list. For alternative methods of deploying your book online, see the See the [Jupyter Book documentation](https://jupyterbook.org/intro.html).

--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -61,7 +61,7 @@ def test_cookiecutter_all_options(base_command, open_source_license, include_ci)
 
 def test_jupyter_book_cookiecutter(base_command):
     # same tests being run in the Jupyter Book test regime
-    # https://github.com/executablebooks/jupyter-book/blob/master/tests/test_build.py#L26-L35
+    # https://github.com/executablebooks/jupyter-book/blob/main/tests/test_build.py#L26-L35
     # note that default cookiecutter book name is "my_book" which is why it's used below
     path = Path(base_command[1])
     result = subprocess.run(base_command[0], shell=True)

--- a/{{cookiecutter.book_slug}}/.github/workflows/deploy.yml
+++ b/{{cookiecutter.book_slug}}/.github/workflows/deploy.yml
@@ -1,10 +1,10 @@
 name: deploy
 
 on:
-  # Trigger the workflow on push to master branch
+  # Trigger the workflow on push to main branch
   push:
     branches:
-      - master
+      - main
 
 # This job installs dependencies, build the book, and pushes it to `gh-pages`
 jobs:
@@ -33,7 +33,7 @@ jobs:
 
     # Deploy the book's HTML to gh-pages branch
     - name: GitHub Pages action
-      uses: peaceiris/actions-gh-pages@v3.6.1
+      uses: peaceiris/actions-gh-pages@v3.6.4
       with:
         github_token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
         publish_dir: {{ cookiecutter.book_slug }}/_build/html

--- a/{{cookiecutter.book_slug}}/.github/workflows/deploy.yml
+++ b/{{cookiecutter.book_slug}}/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
 
     # Deploy the book's HTML to gh-pages branch
     - name: GitHub Pages action
-      uses: peaceiris/actions-gh-pages@v3.6.4
+      uses: peaceiris/actions-gh-pages@v3.6.1
       with:
         github_token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
         publish_dir: {{ cookiecutter.book_slug }}/_build/html

--- a/{{cookiecutter.book_slug}}/README.md
+++ b/{{cookiecutter.book_slug}}/README.md
@@ -17,7 +17,7 @@ A fully-rendered HTML version of the book will be built in `{{ cookiecutter.book
 
 ### Hosting the book
 
-The html version of the book is hosted on the `gh-pages` branch of this repo. A GitHub actions workflow has been created that automatically builds and pushes the book to this branch on a push or pull request to master.
+The html version of the book is hosted on the `gh-pages` branch of this repo. A GitHub actions workflow has been created that automatically builds and pushes the book to this branch on a push or pull request to main.
 
 If you wish to disable this automation, you may remove the GitHub actions workflow and build the book manually by:
 


### PR DESCRIPTION
As per the announcement that GitHub is phasing out the "master" terminology in preference of "main" (which is now the default name for new repositories), the cookiecutter has been updated to use "main".

Resolves #20 