### PR TITLE
🐛 FIX: Update typo in cookiecutter readme

### DIFF
--- a/{{cookiecutter.book_slug}}/README.md
+++ b/{{cookiecutter.book_slug}}/README.md
@@ -6,25 +6,21 @@
 
 ### Building the book
 
-If you'd like to develop on and build the {{ cookiecutter.book_name }} book, you should:
+If you'd like to develop and/or build the {{ cookiecutter.book_name }} book, you should:
 
-- Clone this repository and run
-- Run `pip install -r requirements.txt` (it is recommended you do this within a virtual environment)
-- (Recommended) Remove the existing `{{ cookiecutter.book_name }}/_build/` directory
-- Run `jupyter-book build {{ cookiecutter.book_name }}/`
+1. Clone this repository
+2. Run `pip install -r requirements.txt` (it is recommended you do this within a virtual environment)
+3. (Optional) Edit the books source files located in the `{{ cookiecutter.book_slug }}/` directory
+4. Run `jupyter-book clean {{ cookiecutter.book_slug }}/` to remove any existing builds
+5. Run `jupyter-book build {{ cookiecutter.book_slug }}/`
 
-A fully-rendered HTML version of the book will be built in `{{ cookiecutter.book_name }}/_build/html/`.
+A fully-rendered HTML version of the book will be built in `{{ cookiecutter.book_slug }}/_build/html/`.
 
 ### Hosting the book
 
-The html version of the book is hosted on the `gh-pages` branch of this repo. A GitHub actions workflow has been created that automatically builds and pushes the book to this branch on a push or pull request to main.
+Please see the [Jupyter Book documentation](https://jupyterbook.org/publish/web.html) to discover options for deploying a book online using services such as GitHub, GitLab, or Netlify.
 
-If you wish to disable this automation, you may remove the GitHub actions workflow and build the book manually by:
-
-- Navigating to your local build; and running,
-- `ghp-import -n -p -f {{ cookiecutter.book_name }}/_build/html`
-
-This will automatically push your build to the `gh-pages` branch. More information on this hosting process can be found [here](https://jupyterbook.org/publish/gh-pages.html#manually-host-your-book-with-github-pages).
+For GitHub and GitLab deployment specifically, the [cookiecutter-jupyter-book](https://github.com/executablebooks/cookiecutter-jupyter-book) includes templates for, and information about, optional continuous integration (CI) workflow files to help easily and automatically deploy books online with GitHub or GitLab. For example, if you chose `github` for the `include_ci` cookiecutter option, your book template was created with a GitHub actions workflow file that, once pushed to GitHub, automatically renders and pushes your book to the `gh-pages` branch of your repo and hosts it on GitHub Pages when a push or pull request is made to the main branch.
 
 ## Contributors
 


### PR DESCRIPTION
Closes: #31 and more generally clarifies some things in the cookiecutter readme.