### PR TITLE
🔧 MAINTAIN: more robust gitlab-ci trigger

### DIFF
--- a/{{cookiecutter.book_slug}}/.gitlab-ci.yml
+++ b/{{cookiecutter.book_slug}}/.gitlab-ci.yml
@@ -31,3 +31,9 @@ pages:
       - public
   only:
     - master
+    
+workflow:
+  rules:
+    - if: $CI_COMMIT_REF_NAME =~ /-wip$/
+      when: never
+    - if: '$CI_PIPELINE_SOURCE == "push"'

--- a/{{cookiecutter.book_slug}}/.gitlab-ci.yml
+++ b/{{cookiecutter.book_slug}}/.gitlab-ci.yml
@@ -30,10 +30,10 @@ pages:
     paths:
       - public
   only:
-    - master
+    - main
     
 workflow:
   rules:
-    - if: $CI_COMMIT_REF_NAME =~ /-wip$/
+    - if: $CI_COMMIT_REF_NAME =~ /-wip$/  # Pipelines for branch or tag names that include -wip don't run
       when: never
     - if: '$CI_PIPELINE_SOURCE == "push"'


### PR DESCRIPTION
With this addition, CI reliably triggers on push 