### PR TITLE
Install jupyter-book along with cookiecutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ my_book
 1. Install [Cookiecutter](https://github.com/cookiecutter/cookiecutter/tree/1.7.2) if you haven't installed it yet:
 
 ```bash
-$ pip install -U cookiecutter
+$ pip install -U cookiecutter jupyter-book
 ```
 
 2. Use `cookiecutter-jupyter-book` to generate a Jupyter Book template and fill out the requested information (default templating values are shown in square brackets `[]` and will be used if no other information is entered):


### PR DESCRIPTION
The hooks seem to import jupyter-book, so the
instructions as provided fail with the following error:

```
3 - no
Choose from 1, 2, 3 [1]: 1
Traceback (most recent call last):
  File "/var/folders/p4/gnx7h_mj73v92nj_v93475v80000gn/T/tmpe50bxgoh.py", line 5, in <module>
    import jupyter_book
ModuleNotFoundError: No module named 'jupyter_book'
ERROR: Stopping generation because post_gen_project hook script didn't exit successfully
Hook script failed (exit status: 1)
```