### PR TITLE
Jupyterbook on GitHub Pages directly from action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           jupyter-book build .
 
-      # Upload the book's HTML as an artifact (optional)
+      # Upload the book's HTML as an artifact
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,12 +9,6 @@ on:
 env:
   BASE_URL: /${{ github.event.repository.name }}
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
@@ -24,6 +18,10 @@ concurrency:
 jobs:
   deploy-book:
     runs-on: ubuntu-latest
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,18 +36,23 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
-
-      # Build the book
-      - name: Build the book
+      # Use default CC
+      - name: Cookiecutter no GHA
         run: |
-          jupyter-book build .
-
+          cookiecutter . --no-input include_ci=no
+      # Install requirements.txt
+      - name: Install requirements
+        run: |
+          pip install -r my_book/requirements.txt
+      # Build the example book
+      - name: Build book
+        run: |
+          jupyter-book build my_book/my_book/
       # Upload the book's HTML as an artifact
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
         with:
-          path: "_build/html"
-
+          path: "my_book/my_book/_build/html"
       # Deploy the book's HTML to GitHub Pages
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,15 +42,11 @@ jobs:
         run: |
           jupyter-book build .
 
-      # Setup for GitHub Pages deployment
-      - name: Setup Pages
-        uses: actions/configure-pages@v3
-
       # Upload the book's HTML as an artifact (optional)
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v2
         with:
-          path: "./_build/html"
+          path: "_build/html"
 
       # Deploy the book's HTML to GitHub Pages
       - name: Deploy to GitHub Pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,52 +1,58 @@
-name: deploy
+name: deploy-book
 
 on:
   # Trigger the deploy on push to main branch
   push:
     branches:
       - main
-  schedule:
-    # jupyter-book is updated regularly, let's run this deployment every month in case something fails
-    # <minute [0,59]> <hour [0,23]> <day of the month [1,31]> <month of the year [1,12]> <day of the week [0,6]>
-    # https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07
-    # https://crontab.guru/every-month
-    # Run cron job every month
-    - cron: '0 0 1 * *'
 
-jobs: 
-  # This job deploys the example book
-  deploy-example-book:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: [3.8]
+env:
+  BASE_URL: /${{ github.event.repository.name }}
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy-book:
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    # Install CC
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        pip install -r requirements.txt
-    # Use default CC
-    - name: Cookiecutter no GHA
-      run: |
-        cookiecutter . --no-input include_ci=no
-    # Install requirements.txt
-    - name: Install requirements
-      run: |
-        pip install -r my_book/requirements.txt
-    # Build the example book
-    - name: Build book
-      run: |
-        jupyter-book build my_book/my_book/
-    # Deploy html to gh-pages
-    - name: GitHub Pages action
-      uses: peaceiris/actions-gh-pages@v3.6.1
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: my_book/my_book/_build/html
-        publish_branch: gh-pages
+      - uses: actions/checkout@v3
+
+      # Install dependencies
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+
+      # Build the book
+      - name: Build the book
+        run: |
+          jupyter-book build .
+
+      # Setup for GitHub Pages deployment
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      # Upload the book's HTML as an artifact (optional)
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: "./_build/html"
+
+      # Deploy the book's HTML to GitHub Pages
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,12 @@ on:
     - cron: '0 0 1 * *'
   workflow_dispatch:
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   # This job tests that the CC works
   test-cc-and-jb-build:
@@ -22,12 +28,13 @@ jobs:
         os: [ubuntu-latest]  # currently not testing on windows
         python-version: [3.9]
     steps:
-    - uses: actions/checkout@v2
-    # Setup
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v3
+
+    # Install dependencies
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.11
     - name: Install dependencies
       run: |
         pip install -r requirements.txt
@@ -44,11 +51,9 @@ jobs:
       run: |
         cookiecutter . --no-input --overwrite-if-exists
         pip install -r my_book/requirements.txt
-        jupyter-book build my_book/my_book/
-    # Push example book to gh-pages-test
-    - name: GitHub Pages action
-      uses: peaceiris/actions-gh-pages@v3.6.1
+        jupyter-book build .
+    # Upload the book's HTML as an artifact
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v2
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: my_book/my_book/_build/html
-        publish_branch: gh-pages-test
+        path: "_build/html"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,20 +13,14 @@ on:
     - cron: '0 0 1 * *'
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 jobs:
   # This job tests that the CC works
   test-cc-and-jb-build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]  # currently not testing on windows
-        python-version: [3.9]
+    runs-on: ubuntu-latest
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      pages: write
+      id-token: write
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,14 +46,24 @@ jobs:
     - name: Pytest tests
       run: |
         pytest
-    # Build the example book
-    - name: Build default book
+    # Use default CC
+    - name: Cookiecutter no GHA
       run: |
-        cookiecutter . --no-input --overwrite-if-exists
+        cookiecutter . --no-input --overwrite-if-exists include_ci=no 
+    # Install requirements.txt
+    - name: Install requirements
+      run: |
         pip install -r my_book/requirements.txt
-        jupyter-book build .
+    # Build the example book
+    - name: Build book
+      run: |
+        jupyter-book build my_book/my_book/
     # Upload the book's HTML as an artifact
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v2
       with:
-        path: "_build/html"
+        path: "my_book/my_book/_build/html"
+    # Deploy the book's HTML to GitHub Pages
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v2

--- a/{{cookiecutter.book_slug}}/.github/workflows/deploy.yml
+++ b/{{cookiecutter.book_slug}}/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           jupyter-book build .
 
-      # Upload the book's HTML as an artifact (optional)
+      # Upload the book's HTML as an artifact
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
         with:

--- a/{{cookiecutter.book_slug}}/.github/workflows/deploy.yml
+++ b/{{cookiecutter.book_slug}}/.github/workflows/deploy.yml
@@ -9,12 +9,6 @@ on:
 env:
   BASE_URL: {% raw %}/${{ github.event.repository.name }}{% endraw %}
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
@@ -24,6 +18,10 @@ concurrency:
 jobs:
   deploy-book:
     runs-on: ubuntu-latest
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v3
 

--- a/{{cookiecutter.book_slug}}/.github/workflows/deploy.yml
+++ b/{{cookiecutter.book_slug}}/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 env:
-  BASE_URL: /${{ github.event.repository.name }}
+  BASE_URL: {% raw %}/${{ github.event.repository.name }}{% endraw %}
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/{{cookiecutter.book_slug}}/.github/workflows/deploy.yml
+++ b/{{cookiecutter.book_slug}}/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: deploy
+name: deploy-book
 
 on:
   # Trigger the workflow on push to main branch
@@ -6,34 +6,53 @@ on:
     branches:
       - main
 
-# This job installs dependencies, build the book, and pushes it to `gh-pages`
+env:
+  BASE_URL: /${{ github.event.repository.name }}
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
-  build-and-deploy-book:
-    runs-on: {% raw %}${{ matrix.os }}{% endraw %}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: [3.8]
+  deploy-book:
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-    # Install dependencies
-    - name: Set up Python {% raw %}${{ matrix.python-version }}{% endraw %}
-      uses: actions/setup-python@v1
-      with:
-        python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
-    - name: Install dependencies
-      run: |
-        pip install -r requirements.txt
+      # Install dependencies
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
 
-    # Build the book
-    - name: Build the book
-      run: |
-        jupyter-book build {{ cookiecutter.book_slug }}
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
 
-    # Deploy the book's HTML to gh-pages branch
-    - name: GitHub Pages action
-      uses: peaceiris/actions-gh-pages@v3.6.1
-      with:
-        github_token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
-        publish_dir: {{ cookiecutter.book_slug }}/_build/html
+      # Build the book
+      - name: Build the book
+        run: |
+          jupyter-book build .
+
+      # Setup for GitHub Pages deployment
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      # Upload the book's HTML as an artifact (optional)
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: "./_build/html"
+
+      # Deploy the book's HTML to GitHub Pages
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/{{cookiecutter.book_slug}}/.github/workflows/deploy.yml
+++ b/{{cookiecutter.book_slug}}/.github/workflows/deploy.yml
@@ -42,15 +42,11 @@ jobs:
         run: |
           jupyter-book build .
 
-      # Setup for GitHub Pages deployment
-      - name: Setup Pages
-        uses: actions/configure-pages@v3
-
       # Upload the book's HTML as an artifact (optional)
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v2
         with:
-          path: "./_build/html"
+          path: "_build/html"
 
       # Deploy the book's HTML to GitHub Pages
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
With these changes, bringing a JupyterBook to GitHub pages is simply:
activate "Deploy from GitHub actions", no need for a gh-pages branch anymore.

Follow-Up to this discussion on the Myst Markdown Discord:
https://discord.com/channels/1083088970059096114/1083088970059096117/1158825259315777600

The new workflow was tested here:
https://github.com/kolibril13/jupyterbook-directly-from-action

cc. @agoose77

