### PR TITLE
fix: `deploy-book` action doesn't work out-of-the-box

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
         with:
-          path: "my_book/my_book/_build/html"
+          path: ${{ github.event.repository.name }}/_build/html
       # Deploy the book's HTML to GitHub Pages
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
Hopefully, this fixes #47, following the prescription described by @chillerb in https://github.com/executablebooks/cookiecutter-jupyter-book/issues/47#issuecomment-2432730919.

I have assumed that `YOUR BOOK DIRECTORY` is `${{ github.event.repository.name }}` from context; it's used to define the base directory variable earlier in the YAML.

This PR is untested! I think the only way to fully check it is to try using the cookie to make a new repo and verify that it sets up GitHub Actions appropriately.