### PR TITLE
chore: should format_version and jupytext_version be updated?

### DIFF
--- a/{{cookiecutter.book_slug}}/{{cookiecutter.book_slug}}/markdown-notebooks.md
+++ b/{{cookiecutter.book_slug}}/{{cookiecutter.book_slug}}/markdown-notebooks.md
@@ -5,8 +5,8 @@ jupytext:
   text_representation:
     extension: .md
     format_name: myst
-    format_version: 0.13
-    jupytext_version: 1.11.5
+    format_version: 4.0.0
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3
   language: python


### PR DESCRIPTION
I've been using the default that this cookiecutter provides, but I think I'm missing out on features because this hard-coded number is holding me back. It's also copy-pasted from one new Markdown file to the next, so it's hard to manage this way. Can it be a global (per-project) setting?