### PR TITLE
chore: update `upload-pages-artifact` and `deploy-pages` actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,10 +48,10 @@ jobs:
           jupyter-book build my_book/my_book/
       # Upload the book's HTML as an artifact
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: "my_book/my_book/_build/html"
       # Deploy the book's HTML to GitHub Pages
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
GitHub started refusing these with

```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

(Presumably, `upload-pages-artifact@v2` uses `upload-artifact@v3`, and we need to update these downstream dependents to get the upstream dependencies up-to-date.)